### PR TITLE
Make boost a required dependency for test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,8 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -j4 -C ${CMAKE_CFG_INTDIR
 #set_property(TARGET compile_tests PROPERTY CXX_STANDARD ${CXX_STD})
 #target_link_libraries(compile_tests parser)
 
+find_package(Boost REQUIRED)
+
 macro(add_test_executable name)
     add_executable(${name} ${name}.cpp)
     target_include_directories(${name} INTERFACE ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
test_basics.cpp does not build if boost is not found, so make boost a required dependency.

If boost should not be a required dependency, the test should be modified to build without boost.