### PR TITLE
Remove googletest dependency

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -7,17 +7,3 @@
 # Boost
 ###############################################################################
 find_package(Boost)
-
-###############################################################################
-# GoogleTest
-###############################################################################
-add_subdirectory(${CMAKE_SOURCE_DIR}/googletest-release-1.10.0)
-target_include_directories(gtest      INTERFACE ${CMAKE_HOME_DIRECTORY}/googletest-release-1.10.0/googletest/include)
-target_include_directories(gtest_main INTERFACE ${CMAKE_HOME_DIRECTORY}/googletest-release-1.10.0/googletest/include)
-
-
-###############################################################################
-# Google Benchmark
-###############################################################################
-add_subdirectory(${CMAKE_SOURCE_DIR}/benchmark-v1.1.0)
-target_include_directories(benchmark INTERFACE ${CMAKE_HOME_DIRECTORY}/benchmark-v1.1.0/include)


### PR DESCRIPTION
Googletest is not used any more, so remove it as a dependency.

I don't really understand the tests yet, but it seems that googletest is not used any more. Or is it?