### PR TITLE
Add missing include to cstdint for usage of uint8_t

### DIFF
--- a/include/boost/flags.hpp
+++ b/include/boost/flags.hpp
@@ -15,9 +15,10 @@
 #ifndef BOOST_FLAGS_HPP_INCLUDED
 #define BOOST_FLAGS_HPP_INCLUDED
 
+#include <cstdint>
+#include <iterator>
 #include <type_traits>
 #include <utility>
-#include <iterator>
 
 
 /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
While at it, sort the includes alphabetically to satisfy the monk.

Fixes https://github.com/tobias-loew/flags/issues/27